### PR TITLE
🔧 Try to fix translate

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -7,6 +7,10 @@ const nextConfig = {
 				protocol: 'https',
 				hostname: '**.andy-cinquin.fr',
 			},
+			{
+				protocol: 'https',
+				hostname: '**.andy-cinquin.com',
+			},
 		],
 	},
 	experimental: {
@@ -20,12 +24,12 @@ const nextConfig = {
 		defaultLocale: 'fr',
 		domains: [
 			{
-				domain: 'andy-cinquin.fr',
+				domain: '**.andy-cinquin.fr',
 				defaultLocale: 'fr',
 				locales: ['fr'],
 			},
 			{
-				domain: 'andy-cinquin.com',
+				domain: '**.andy-cinquin.com',
 				defaultLocale: 'en',
 				locales: ['en'],
 			},


### PR DESCRIPTION
🔧 Try to fix translate

Updated the next.config.js file to include additional domains for translation. Added support for the domain "**.andy-cinquin.com" with the default locale set to "en". Also updated the existing domain "andy-cinquin.fr" to include a wildcard subdomain "**." for better localization.