### PR TITLE
🔧 Update next.config.js to allow all hostnames

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -5,7 +5,7 @@ const nextConfig = {
 		remotePatterns: [
 			{
 				protocol: 'https',
-				hostname: '**.andy-cinquin.**',
+				hostname: '**',
 			},
 		],
 	},


### PR DESCRIPTION
This commit updates the `next.config.js` file to allow all hostnames instead of a specific one. This change was made in the `remotePatterns` section by modifying the `hostname` property.
🔧 Update next.config.js to allow all hostnames

This commit modifies the `next.config.js` file to allow all hostnames instead of a specific one. The change was made in the `remotePatterns` section by updating the `hostname` property to `"**"`.
