### PR TITLE
🔧 Fix broken image source URL

### DIFF
--- a/src/pages/portefolio/[slug].js
+++ b/src/pages/portefolio/[slug].js
@@ -168,7 +168,7 @@ function Talent({ content_website, realisations }) {
 												className="relative flex items-center justify-center"
 											>
 												<Image
-													src="/assets/icons/3d.svg"
+													src={`${process.env.NEXT_PUBLIC_URL}/assets/icons/3d.svg`}
 													alt="icon-3d"
 													width={80}
 													height={80}


### PR DESCRIPTION
The commit fixes a broken image source URL in the [slug].js file. The previous URL was not correctly referencing the 3d.svg icon, causing it to not display properly. The fix updates the URL to use the correct path by appending `${process.env.NEXT_PUBLIC_URL}` before `/assets/icons/3d.svg`.
