### PR TITLE
🔧 Add console logs for debugging

### DIFF
--- a/src/pages/sitemap.xml.js
+++ b/src/pages/sitemap.xml.js
@@ -51,6 +51,7 @@ export const getServerSideProps = async ({ res }) => {
 			.replace(/\\/g, '/')
 		return `${process.env.NEXT_PUBLIC_URL}/${newPath}`
 	})
+	console.log('staticPaths', staticPaths)
 
 	// Filter out unwanted paths
 	staticPaths = staticPaths.filter(item => {
@@ -82,6 +83,8 @@ export const getServerSideProps = async ({ res }) => {
 		staticPathsAlt,
 		process.env.NEXT_PUBLIC_URL_ALT
 	)
+	console.log('staticPaths', staticPaths)
+	console.log('staticPathsAlt', staticPathsAlt)
 
 	// get all article for dynamic paths
 	const resultBlog = await fetch(
@@ -96,17 +99,21 @@ export const getServerSideProps = async ({ res }) => {
 			},
 		}
 	).then(res => res.json())
+	console.log('resultBlog', resultBlog)
 
 	const pathsBlog = resultBlog?.data?.map(record => {
 		return `${process.env.NEXT_PUBLIC_URL}/blog/${record.attributes.slug}`
 	})
+	console.log('pathsBlog', pathsBlog)
 
 	// copy of the paths for the alternative URL
 	const resultBlogAlt = JSON.parse(JSON.stringify(resultBlog))
+	console.log('resultBlogAlt', resultBlogAlt)
 
 	const pathsBlogAlt = resultBlogAlt?.data?.map(record => {
 		return `${process.env.NEXT_PUBLIC_URL_ALT}/blog/${record.attributes.localizations?.data[0]?.attributes?.slug}`
 	})
+	console.log('pathsBlogAlt', pathsBlogAlt)
 
 	// get all article for dynamic paths
 	const resultPortefolio = await fetch(
@@ -121,16 +128,20 @@ export const getServerSideProps = async ({ res }) => {
 			},
 		}
 	).then(res => res.json())
+	console.log('resultPortefolio', resultPortefolio)
 
 	const pathsPortefolio = resultPortefolio?.data?.map(record => {
 		return `${process.env.NEXT_PUBLIC_URL}/portefolio/${record.attributes.slug}`
 	})
+	console.log('pathsPortefolio', pathsPortefolio)
 
 	const resultPortefolioAlt = JSON.parse(JSON.stringify(resultPortefolio))
+	console.log('resultPortefolioAlt', resultPortefolioAlt)
 
 	const pathsPortefolioAlt = resultPortefolioAlt?.data?.map(record => {
 		return `${process.env.NEXT_PUBLIC_URL_ALT}/portefolio/${record.attributes.localizations?.data[0]?.attributes?.slug}`
 	})
+	console.log('pathsPortefolioAlt', pathsPortefolioAlt)
 
 	const allPaths = [
 		...staticPaths,
@@ -140,6 +151,7 @@ export const getServerSideProps = async ({ res }) => {
 		...pathsBlogAlt,
 		...pathsPortefolioAlt,
 	]
+	console.log('allPaths', allPaths)
 
 	// Generate the sitemap
 	const sitemap = `<?xml version="1.0" encoding="UTF-8"?>


### PR DESCRIPTION
This commit adds console logs to aid in debugging. The added console logs include 'staticPaths', 'staticPathsAlt', 'resultBlog', 'pathsBlog', 'resultBlogAlt', 'pathsBlogAlt', 'resultPortefolio', 'pathsPortefolio', 'resultPortefolioAlt', and 'pathsPortefolioAlt'. These console logs will help track the values of these variables during runtime and assist in identifying any issues or errors.
