### PR TITLE
🔧 Update sitemap.xml.js

### DIFF
--- a/src/pages/sitemap.xml.js
+++ b/src/pages/sitemap.xml.js
@@ -8,8 +8,8 @@ const Sitemap = () => {
 export const getServerSideProps = async ({ res }) => {
 	console.log('process.env.NEXT_PUBLIC_URL', process.env.NEXT_PUBLIC_URL)
 	console.log(
-		'process.env.NEXT_PUBLIC_API_URL',
-		process.env.NEXT_PUBLIC_API_URL
+		'process.env.NEXT_PUBLIC_URL_ALT',
+		process.env.NEXT_PUBLIC_URL_ALT
 	)
 
 	// Function to get directories from a directory recursively


### PR DESCRIPTION
- Updated console.log statements to use NEXT_PUBLIC_URL_ALT instead of NEXT_PUBLIC_API_URL
- No longer using the process.env.NEXT_PUBLIC_API_URL variable in the code
